### PR TITLE
Improve consent handling

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/fb-tag'
 versions:
+  - sha: 7cf88f8c6dd13df634d10a38b23b289df562dd28
+    changeNotes: Refactored consent handling.
   - sha: 1107c20795f06f3fc51f77134c3a4d5b8f711c46
     changeNotes: Fixed an issue with autoConfig command.
   - sha: 26fdd16454bed7e4c46f1cd69bba43e2593b8fbf

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/fb-tag'
 versions:
-  - sha: 7cf88f8c6dd13df634d10a38b23b289df562dd28
+  - sha: ff8c93359d634c3221f5c02b21c9c32b079c6529
     changeNotes: Refactored consent handling.
   - sha: 1107c20795f06f3fc51f77134c3a4d5b8f711c46
     changeNotes: Fixed an issue with autoConfig command.

--- a/template.js
+++ b/template.js
@@ -16,21 +16,38 @@ const math = require('Math');
 const Object = require('Object');
 const setInWindow = require('setInWindow');
 const sha256 = require('sha256');
+const templateStorage = require('templateStorage');
+
+// Call-once methods.
+let gtmOnSuccess = () => {
+  gtmOnSuccess = () => {};
+  return data.gtmOnSuccess();
+};
+
+let gtmOnFailure = () => {
+  gtmOnFailure = () => {};
+  return data.gtmOnFailure();
+};
 
 /*==============================================================================
 ==============================================================================*/
 
-const partnerName = 'stape-gtm-1.1.0';
 const queueName = 'fbq';
 const queue = getQueue(queueName);
-const initIds = copyFromWindow('_meta_gtm_ids') || [];
-const dataLayerVersion = data.enableCurrentDataLayerOnly ? 1 : 2;
+const isConsentRevoked = data.enableConsentMode ? !isConsentGranted('ad_storage') : data.consent === false;
+const partnerName = 'stape-gtm-1.1.1';
 
-setConsent();
+setConsent(isConsentRevoked);
 sendEvent();
 sendDataLayerPush();
+runOnConsent('ad_storage', () => {
+  loadScripts();
+});
 
-injectScript('https://connect.facebook.net/en_US/fbevents.js', data.gtmOnSuccess, data.gtmOnFailure, 'metaPixel');
+if (isConsentRevoked) {
+  // If consent is revoked, call gtmOnSuccess to avoid 'Still running' status.
+  return gtmOnSuccess();
+}
 
 /*==============================================================================
   Vendor related functions
@@ -38,17 +55,12 @@ injectScript('https://connect.facebook.net/en_US/fbevents.js', data.gtmOnSuccess
 
 function getQueue(queueName) {
   const q = copyFromWindow(queueName);
-  if (q) {
-    return q;
-  }
+  if (q) return q;
 
   setInWindow(queueName, function () {
     const callMethod = copyFromWindow(queueName + '.callMethod.apply');
-    if (callMethod) {
-      callInWindow(queueName + '.callMethod.apply', null, arguments);
-    } else {
-      callInWindow(queueName + '.queue.push', arguments);
-    }
+    if (callMethod) callInWindow(queueName + '.callMethod.apply', null, arguments);
+    else callInWindow(queueName + '.queue.push', arguments);
   });
 
   aliasInWindow('_' + queueName, queueName);
@@ -57,33 +69,55 @@ function getQueue(queueName) {
   return copyFromWindow(queueName);
 }
 
-function setConsent() {
+function setFbqConsent(command) {
+  const queue = getQueue(queueName);
+  if (command === 'revoke') {
+    // Allows only one 'revoke' command at a time in the queue to avoid it being locked indefinitely.
+    const queueHasRevokeCommand = (queue.queue || []).some((item) => item[0] === 'consent' && item[1] === 'revoke');
+    if (queueHasRevokeCommand) return;
+  }
+  queue('consent', command);
+}
+
+function runOnConsent(consentType, callback) {
+  if (data.enableConsentMode) {
+    if (isConsentGranted(consentType)) {
+      callback();
+    } else {
+      const callbacksKey = 'fbq_consent_callbacks_' + consentType;
+      const callbacks = templateStorage.getItem(callbacksKey) || [];
+      callbacks.push(callback);
+      templateStorage.setItem(callbacksKey, callbacks);
+
+      const listenerAddedKey = 'fbq_consent_listener_added_' + consentType;
+      if (!templateStorage.getItem(listenerAddedKey)) {
+        templateStorage.setItem(listenerAddedKey, true);
+        addConsentListener(consentType, (type, granted) => {
+          if (type !== consentType || !granted) return;
+          const queuedCallbacks = templateStorage.getItem(callbacksKey) || [];
+          queuedCallbacks.forEach((cb) => cb());
+          templateStorage.setItem(callbacksKey, []);
+        });
+      }
+    }
+    return;
+  }
+
+  const isConsentManuallyGranted = data.consent !== false;
+  if (isConsentManuallyGranted) callback();
+}
+
+function setConsent(isConsentRevoked) {
   if (data.dpoLDU) {
     queue('dataProcessingOptions', ['LDU'], makeNumber(data.dpoCountry), makeNumber(data.dpoState));
   }
 
-  if (data.enableConsentMode) {
-    if (!isConsentGranted('ad_storage')) {
-      queue('consent', 'revoke');
+  if (isConsentRevoked) setFbqConsent('revoke');
 
-      let wasCalled = false;
-
-      addConsentListener('ad_storage', (consentType, granted) => {
-        if (wasCalled || consentType !== 'ad_storage' || !granted) return;
-        wasCalled = true;
-
-        queue('consent', 'grant');
-      });
-
-      return;
-    }
-
-    queue('consent', 'grant');
-
-    return;
-  }
-
-  queue('consent', data.consent === false ? 'revoke' : 'grant');
+  // Wait for consent to send 'grant'
+  runOnConsent('ad_storage', () => {
+    setFbqConsent('grant');
+  });
 }
 
 function setSettings(pixelId) {
@@ -97,6 +131,7 @@ function setSettings(pixelId) {
 }
 
 function sendEvent() {
+  const initIds = copyFromWindow('_meta_gtm_ids') || [];
   const pixelIds = data.pixelIds;
   const eventName = getEventName();
   const command = getCommand(eventName);
@@ -522,7 +557,20 @@ function getGA4EventData(eventName, objectProperties, ecommerce) {
 }
 
 function getDL(name) {
+  const dataLayerVersion = data.enableCurrentDataLayerOnly ? 1 : 2;
   return copyFromDataLayer(name, dataLayerVersion);
+}
+
+function loadScripts() {
+  injectScript(
+    'https://connect.facebook.net/en_US/fbevents.js',
+    () => {
+      setFbqConsent('grant'); // It needs to be called to unlock the queue after the SDK loads.
+      return gtmOnSuccess();
+    },
+    gtmOnFailure,
+    'metaPixel'
+  );
 }
 
 /*==============================================================================

--- a/template.js
+++ b/template.js
@@ -40,7 +40,7 @@ const partnerName = 'stape-gtm-1.1.1';
 setConsent(isConsentRevoked);
 sendEvent();
 sendDataLayerPush();
-runOnConsent('ad_storage', () => {
+runOnConsentGranted('ad_storage', isConsentRevoked, () => {
   loadScripts();
 });
 
@@ -79,11 +79,9 @@ function setFbqConsent(command) {
   queue('consent', command);
 }
 
-function runOnConsent(consentType, callback) {
+function runOnConsentGranted(consentType, isConsentRevoked, callback) {
   if (data.enableConsentMode) {
-    if (isConsentGranted(consentType)) {
-      callback();
-    } else {
+    if (isConsentRevoked) {
       const callbacksKey = 'fbq_consent_callbacks_' + consentType;
       const callbacks = templateStorage.getItem(callbacksKey) || [];
       callbacks.push(callback);
@@ -95,16 +93,18 @@ function runOnConsent(consentType, callback) {
         addConsentListener(consentType, (type, granted) => {
           if (type !== consentType || !granted) return;
           const queuedCallbacks = templateStorage.getItem(callbacksKey) || [];
-          queuedCallbacks.forEach((cb) => cb());
           templateStorage.setItem(callbacksKey, []);
+          queuedCallbacks.forEach((cb) => cb());
         });
       }
+    } else {
+      callback();
     }
     return;
   }
 
-  const isConsentManuallyGranted = data.consent !== false;
-  if (isConsentManuallyGranted) callback();
+  // Manual consent
+  if (!isConsentRevoked) callback();
 }
 
 function setConsent(isConsentRevoked) {
@@ -114,8 +114,7 @@ function setConsent(isConsentRevoked) {
 
   if (isConsentRevoked) setFbqConsent('revoke');
 
-  // Wait for consent to send 'grant'
-  runOnConsent('ad_storage', () => {
+  runOnConsentGranted('ad_storage', isConsentRevoked, () => {
     setFbqConsent('grant');
   });
 }

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-﻿___TERMS_OF_SERVICE___
+___TERMS_OF_SERVICE___
 
 By creating or modifying this file you agree to Google Tag Manager's Community
 Template Gallery Developer Terms of Service available at
@@ -56,8 +56,9 @@ ___TEMPLATE_PARAMETERS___
             ]
           }
         ],
-        "help": "Set to a valid Facebook Pixel ID.",
-        "alwaysInSummary": true
+        "help": "Array, single item string or comma separated string of Pixel IDs.",
+        "alwaysInSummary": true,
+        "valueHint": "1234...,9876..."
       },
       {
         "type": "SELECT",
@@ -206,23 +207,25 @@ ___TEMPLATE_PARAMETERS___
         "simpleValueType": true,
         "help": "If you check this, then the Facebook tag will populate standard Object Properties and User Data automatically from the DataLayer. The tag parses Universal Analytics,  \u003ca target\u003d\"_blank\" href\u003d\"https://developers.google.com/analytics/devguides/collection/ga4/ecommerce\"\u003eGA4\u003c/a\u003e and \u003ca target\u003d\"_blank\" href\u003d\"https://developers.google.com/tag-platform/tag-manager/server-side/common-event-data\"\u003eCommon Event Data\u003c/a\u003e formats.",
         "defaultValue": true,
-        "alwaysInSummary": true
-      },
-      {
-        "type": "CHECKBOX",
-        "name": "enableCurrentDataLayerOnly",
-        "checkboxText": "Use data only from the most recent Data Layer event where the data can be found (ignore recursive merges)",
-        "simpleValueType": true,
-        "help": "If enabled, the tag will take data only from the most recent Data Layer event where the data can be found. \n\u003cbr/\u003e\u003cbr/\u003e\nIn other words, the tag will ignore recursive merges for Data Layer variables and take only the most recent value of the data. \u003ca href\u003d\"https://www.simoahava.com/gtm-tips/data-layer-variable-versions-explained/\"\u003eLearn more\u003c/a\u003e.\n\u003cbr/\u003e\nThat\u0027s how it worked in the old Facebook pixel tag.",
-        "defaultValue": false,
-        "enablingConditions": [
+        "alwaysInSummary": true,
+        "subParams": [
           {
-            "paramName": "enableDataLayerMapping",
-            "paramValue": true,
-            "type": "EQUALS"
+            "type": "CHECKBOX",
+            "name": "enableCurrentDataLayerOnly",
+            "checkboxText": "Use data only from the most recent Data Layer event where the data can be found (ignore recursive merges)",
+            "simpleValueType": true,
+            "help": "If enabled, the tag will take data only from the most recent Data Layer event where the data can be found. \n\u003cbr/\u003e\u003cbr/\u003e\nIn other words, the tag will ignore recursive merges for Data Layer variables and take only the most recent value of the data. \u003ca href\u003d\"https://www.simoahava.com/gtm-tips/data-layer-variable-versions-explained/\"\u003eLearn more\u003c/a\u003e.\n\u003cbr/\u003e\nThat\u0027s how it worked in the old Facebook pixel tag.",
+            "defaultValue": false,
+            "enablingConditions": [
+              {
+                "paramName": "enableDataLayerMapping",
+                "paramValue": true,
+                "type": "EQUALS"
+              }
+            ],
+            "alwaysInSummary": true
           }
-        ],
-        "alwaysInSummary": true
+        ]
       },
       {
         "type": "CHECKBOX",
@@ -302,7 +305,7 @@ ___TEMPLATE_PARAMETERS___
           }
         ],
         "simpleValueType": true,
-        "help": "Setting Consent Granted to \u003cstrong\u003efalse\u003c/strong\u003e will prevent the pixel from sending hits until tag fired with Consent Granted \u003cstrong\u003etrue\u003c/strong\u003e. More info \u003ca href\u003d\"hhttps://developers.facebook.com/docs/meta-pixel/implementation/gdpr\"\u003eby this link\u003c/a\u003e.",
+        "help": "Setting Consent Granted to \u003cstrong\u003efalse\u003c/strong\u003e will prevent the pixel from sending hits until tag fired with Consent Granted \u003cstrong\u003etrue\u003c/strong\u003e.\n\u003cbr/\u003e\n\u003ca href\u003d\"https://developers.facebook.com/docs/meta-pixel/implementation/gdpr\"\u003eLearn more\u003c/a\u003e.",
         "enablingConditions": [
           {
             "paramName": "enableConsentMode",
@@ -316,14 +319,14 @@ ___TEMPLATE_PARAMETERS___
         "name": "enableConsentMode",
         "checkboxText": "Enable GTM consent mode support",
         "simpleValueType": true,
-        "help": "If enabled, the tag will check for ad_storage, and if it not granted, it will set the Facebook pixel consent to revoke. After the consent is granted, it will automatically execute fbq(\u0027consent\u0027, \u0027grant\u0027);"
+        "help": "When enabled, this tag checks for the Google Consent Mode \u003ci\u003ead_storage\u003c/i\u003e consent.\n\u003cbr/\u003e\nIf consent is not granted, the Facebook Pixel consent is set as revoked. \n\u003cbr/\u003e\nIf consent is granted (initially or later), the pixel consent is automatically granted."
       },
       {
         "type": "CHECKBOX",
         "name": "dpoLDU",
         "checkboxText": "Limited Data Use (LDU)",
         "simpleValueType": true,
-        "help": "Limited Data Use is a data processing option that gives you more control over how your data is used in Meta’s systems. More info \u003ca target\u003d\"_blank\" href\u003d\"https://developers.facebook.com/docs/meta-pixel/implementation/data-processing-options\"\u003eby this link\u003c/a\u003e."
+        "help": "Limited Data Use is a data processing option that gives you more control over how your data is used in the system receiving the data. \u003ca target\u003d\"_blank\" href\u003d\"https://developers.facebook.com/docs/meta-pixel/implementation/data-processing-options\"\u003eLearn more\u003c/a\u003e."
       },
       {
         "type": "TEXT",
@@ -374,7 +377,7 @@ ___TEMPLATE_PARAMETERS___
       {
         "type": "LABEL",
         "name": "userDataLabel",
-        "displayName": "User Data Properties that you can send to Meta can be found at \u003ca target\u003d\"_blank\" href\u003d\"https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching\"\u003ethis link\u003c/a\u003e.\u003cbr\u003e\u003cbr\u003e"
+        "displayName": "User Data Properties that you can send to Meta can be found \u003ca target\u003d\"_blank\" href\u003d\"https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching\"\u003ehere\u003c/a\u003e.\u003cbr\u003e\u003cbr\u003e"
       },
       {
         "type": "SELECT",
@@ -479,7 +482,7 @@ ___TEMPLATE_PARAMETERS___
       {
         "type": "LABEL",
         "name": "objectPropertiesLabel",
-        "displayName": "Standard Object Properties that you can send to Meta can be found at \u003ca target\u003d\"_blank\" href\u003d\"https://developers.facebook.com/docs/meta-pixel/reference#object-properties\"\u003ethis link\u003c/a\u003e.\u003cbr\u003e\u003cbr\u003e"
+        "displayName": "Standard Object Properties that you can send to Meta can be found \u003ca target\u003d\"_blank\" href\u003d\"https://developers.facebook.com/docs/meta-pixel/reference#object-properties\"\u003ehere\u003c/a\u003e.\u003cbr\u003e\u003cbr\u003e"
       },
       {
         "type": "SELECT",
@@ -529,7 +532,7 @@ ___TEMPLATE_PARAMETERS___
         "name": "eventId",
         "displayName": "Event ID",
         "simpleValueType": true,
-        "help": "Set the Event ID parameter in case you are tracking the same event server-side as well. The Event ID can be used to deduplicate the same event if sent from multiple sources. See more \u003ca href\u003d\"https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events/\"\u003ehere\u003c/a\u003e."
+        "help": "Set the Event ID parameter in case you are tracking the same event via server-side using the Meta Conversions API.\n\u003cbr/\u003e\nThe Event ID can be used to deduplicate the same event if sent from multiple sources. \n\u003cbr/\u003e\n\u003ca href\u003d\"https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events/\"\u003eLearn more\u003c/a\u003e."
       },
       {
         "type": "GROUP",
@@ -540,7 +543,7 @@ ___TEMPLATE_PARAMETERS___
           {
             "type": "CHECKBOX",
             "name": "dataLayerEventPush",
-            "checkboxText": "Push event to DataLayer with this eventId",
+            "checkboxText": "Push event to DataLayer with this Event ID",
             "simpleValueType": true,
             "help": "Helpful for easier events deduplication.",
             "defaultValue": false
@@ -633,21 +636,38 @@ const math = require('Math');
 const Object = require('Object');
 const setInWindow = require('setInWindow');
 const sha256 = require('sha256');
+const templateStorage = require('templateStorage');
+
+// Call-once methods.
+let gtmOnSuccess = () => {
+  gtmOnSuccess = () => {};
+  return data.gtmOnSuccess();
+};
+
+let gtmOnFailure = () => {
+  gtmOnFailure = () => {};
+  return data.gtmOnFailure();
+};
 
 /*==============================================================================
 ==============================================================================*/
 
-const partnerName = 'stape-gtm-1.1.0';
 const queueName = 'fbq';
 const queue = getQueue(queueName);
-const initIds = copyFromWindow('_meta_gtm_ids') || [];
-const dataLayerVersion = data.enableCurrentDataLayerOnly ? 1 : 2;
+const isConsentRevoked = data.enableConsentMode ? !isConsentGranted('ad_storage') : data.consent === false;
+const partnerName = 'stape-gtm-1.1.1';
 
-setConsent();
+setConsent(isConsentRevoked);
 sendEvent();
 sendDataLayerPush();
+runOnConsent('ad_storage', () => {
+  loadScripts();
+});
 
-injectScript('https://connect.facebook.net/en_US/fbevents.js', data.gtmOnSuccess, data.gtmOnFailure, 'metaPixel');
+if (isConsentRevoked) {
+  // If consent is revoked, call gtmOnSuccess to avoid 'Still running' status.
+  return gtmOnSuccess();
+}
 
 /*==============================================================================
   Vendor related functions
@@ -655,17 +675,12 @@ injectScript('https://connect.facebook.net/en_US/fbevents.js', data.gtmOnSuccess
 
 function getQueue(queueName) {
   const q = copyFromWindow(queueName);
-  if (q) {
-    return q;
-  }
+  if (q) return q;
 
   setInWindow(queueName, function () {
     const callMethod = copyFromWindow(queueName + '.callMethod.apply');
-    if (callMethod) {
-      callInWindow(queueName + '.callMethod.apply', null, arguments);
-    } else {
-      callInWindow(queueName + '.queue.push', arguments);
-    }
+    if (callMethod) callInWindow(queueName + '.callMethod.apply', null, arguments);
+    else callInWindow(queueName + '.queue.push', arguments);
   });
 
   aliasInWindow('_' + queueName, queueName);
@@ -674,33 +689,55 @@ function getQueue(queueName) {
   return copyFromWindow(queueName);
 }
 
-function setConsent() {
+function setFbqConsent(command) {
+  const queue = getQueue(queueName);
+  if (command === 'revoke') {
+    // Allows only one 'revoke' command at a time in the queue to avoid it being locked indefinitely.
+    const queueHasRevokeCommand = (queue.queue || []).some((item) => item[0] === 'consent' && item[1] === 'revoke');
+    if (queueHasRevokeCommand) return;
+  }
+  queue('consent', command);
+}
+
+function runOnConsent(consentType, callback) {
+  if (data.enableConsentMode) {
+    if (isConsentGranted(consentType)) {
+      callback();
+    } else {
+      const callbacksKey = 'fbq_consent_callbacks_' + consentType;
+      const callbacks = templateStorage.getItem(callbacksKey) || [];
+      callbacks.push(callback);
+      templateStorage.setItem(callbacksKey, callbacks);
+
+      const listenerAddedKey = 'fbq_consent_listener_added_' + consentType;
+      if (!templateStorage.getItem(listenerAddedKey)) {
+        templateStorage.setItem(listenerAddedKey, true);
+        addConsentListener(consentType, (type, granted) => {
+          if (type !== consentType || !granted) return;
+          const queuedCallbacks = templateStorage.getItem(callbacksKey) || [];
+          queuedCallbacks.forEach((cb) => cb());
+          templateStorage.setItem(callbacksKey, []);
+        });
+      }
+    }
+    return;
+  }
+
+  const isConsentManuallyGranted = data.consent !== false;
+  if (isConsentManuallyGranted) callback();
+}
+
+function setConsent(isConsentRevoked) {
   if (data.dpoLDU) {
     queue('dataProcessingOptions', ['LDU'], makeNumber(data.dpoCountry), makeNumber(data.dpoState));
   }
 
-  if (data.enableConsentMode) {
-    if (!isConsentGranted('ad_storage')) {
-      queue('consent', 'revoke');
+  if (isConsentRevoked) setFbqConsent('revoke');
 
-      let wasCalled = false;
-
-      addConsentListener('ad_storage', (consentType, granted) => {
-        if (wasCalled || consentType !== 'ad_storage' || !granted) return;
-        wasCalled = true;
-
-        queue('consent', 'grant');
-      });
-
-      return;
-    }
-
-    queue('consent', 'grant');
-
-    return;
-  }
-
-  queue('consent', data.consent === false ? 'revoke' : 'grant');
+  // Wait for consent to send 'grant'
+  runOnConsent('ad_storage', () => {
+    setFbqConsent('grant');
+  });
 }
 
 function setSettings(pixelId) {
@@ -714,6 +751,7 @@ function setSettings(pixelId) {
 }
 
 function sendEvent() {
+  const initIds = copyFromWindow('_meta_gtm_ids') || [];
   const pixelIds = data.pixelIds;
   const eventName = getEventName();
   const command = getCommand(eventName);
@@ -1139,7 +1177,20 @@ function getGA4EventData(eventName, objectProperties, ecommerce) {
 }
 
 function getDL(name) {
+  const dataLayerVersion = data.enableCurrentDataLayerOnly ? 1 : 2;
   return copyFromDataLayer(name, dataLayerVersion);
+}
+
+function loadScripts() {
+  injectScript(
+    'https://connect.facebook.net/en_US/fbevents.js',
+    () => {
+      setFbqConsent('grant'); // It needs to be called to unlock the queue after the SDK loads.
+      return gtmOnSuccess();
+    },
+    gtmOnFailure,
+    'metaPixel'
+  );
 }
 
 /*==============================================================================
@@ -1708,6 +1759,16 @@ ___WEB_PERMISSIONS___
       "isEditedByUser": true
     },
     "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "access_template_storage",
+        "versionId": "1"
+      },
+      "param": []
+    },
+    "isRequired": true
   }
 ]
 
@@ -1715,30 +1776,925 @@ ___WEB_PERMISSIONS___
 ___TESTS___
 
 scenarios:
-- name: Event ID
-  code: "mockData.eventId = 'eventId';\n\nmock('copyFromWindow', key => {\n  if (key\
-    \ === 'fbq') return function() {\n    if (arguments[0] === 'trackSingle') {\n\
-    \      assertThat(arguments[4], 'eventId not set').isEqualTo({eventID: mockData.eventId});\n\
-    \    }\n  };\n});\n     \nrunCode(mockData);\nassertApi('gtmOnSuccess').wasCalled();"
+- name: '[Happy Path] PageView fires init, agent, trackSingle and injects both scripts'
+  code: |-
+    runCode(mockData);
+
+    const consentGrants = fbqCalls.filter((c) => c[0] === 'consent' && c[1] === 'grant');
+    assertThat(consentGrants.length).isGreaterThan(0);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    assertThat(initCalls.length).isEqualTo(1);
+    assertThat(initCalls[0][1]).isEqualTo('123456789');
+
+    const agentCalls = fbqCalls.filter((c) => c[0] === 'set' && c[1] === 'agent');
+    assertThat(agentCalls.length).isEqualTo(1);
+    assertThat(agentCalls[0][2]).isEqualTo(PARTNER_AGENT_VERSION);
+    assertThat(agentCalls[0][3]).isEqualTo('123456789');
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    assertThat(trackCalls.length).isEqualTo(1);
+    assertThat(trackCalls[0][1]).isEqualTo('123456789');
+    assertThat(trackCalls[0][2]).isEqualTo('PageView');
+
+    assertThat(injectScriptCalls.length).isEqualTo(1);
+    assertThat(injectScriptCalls[0].url).isEqualTo('https://connect.facebook.net/en_US/fbevents.js');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Multiple Pixels] Each pixel gets separate init, agent, and track calls'
+  code: |-
+    mockData.pixelIds = '111,222,333';
+
+    runCode(mockData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    assertThat(initCalls.length).isEqualTo(3);
+    assertThat(initCalls[0][1]).isEqualTo('111');
+    assertThat(initCalls[1][1]).isEqualTo('222');
+    assertThat(initCalls[2][1]).isEqualTo('333');
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    assertThat(trackCalls.length).isEqualTo(3);
+    assertThat(trackCalls[0][1]).isEqualTo('111');
+    assertThat(trackCalls[1][1]).isEqualTo('222');
+    assertThat(trackCalls[2][1]).isEqualTo('333');
+
+    const agentCalls = fbqCalls.filter((c) => c[0] === 'set' && c[1] === 'agent');
+    assertThat(agentCalls.length).isEqualTo(3);
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Consent] Manual consent=false revokes fbq and calls gtmOnSuccess without
+    scripts'
+  code: |-
+    mockData.consent = false;
+
+    runCode(mockData);
+
+    const revokeCalls = fbqCalls.filter((c) => c[0] === 'consent' && c[1] === 'revoke');
+    assertThat(revokeCalls.length).isEqualTo(1);
+
+    const grantCalls = fbqCalls.filter((c) => c[0] === 'consent' && c[1] === 'grant');
+    assertThat(grantCalls.length).isEqualTo(0);
+
+    assertThat(injectScriptCalls.length).isEqualTo(0);
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Consent] GTM consent mode denied revokes and calls gtmOnSuccess without
+    scripts'
+  code: |-
+    mockData.enableConsentMode = true;
+    mock('isConsentGranted', () => false);
+
+    runCode(mockData);
+
+    const revokeCalls = fbqCalls.filter((c) => c[0] === 'consent' && c[1] === 'revoke');
+    assertThat(revokeCalls.length).isEqualTo(1);
+
+    assertThat(injectScriptCalls.length).isEqualTo(0);
+
+    assertApi('addConsentListener').wasCalled();
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Consent] Listener fires queued callbacks when consent is later granted'
+  code: |-
+    mockData.enableConsentMode = true;
+    mock('isConsentGranted', () => false);
+
+    let consentListenerCallback;
+    mock('addConsentListener', (type, callback) => {
+      consentListenerCallback = callback;
+    });
+
+    runCode(mockData);
+
+    assertThat(injectScriptCalls.length).isEqualTo(0);
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+
+    consentListenerCallback('ad_storage', true);
+
+    assertThat(injectScriptCalls.length).isEqualTo(1);
+    assertThat(injectScriptCalls[0].url).isEqualTo('https://connect.facebook.net/en_US/fbevents.js');
+
+    const grantCalls = fbqCalls.filter((c) => c[0] === 'consent' && c[1] === 'grant');
+    assertThat(grantCalls.length).isGreaterThan(0);
+- name: '[Consent] setFbqConsent skips duplicate revoke when one is already queued'
+  code: |-
+    const mockFbqWithQueue = function() {
+      const args = [];
+      for (let i = 0; i < arguments.length; i++) {
+        args.push(arguments[i]);
+      }
+      fbqCalls.push(args);
+    };
+    mockFbqWithQueue.queue = [['consent', 'revoke']];
+
+    mock('copyFromWindow', (key) => {
+      if (key === 'fbq') return mockFbqWithQueue;
+      return undefined;
+    });
+
+    mockData.consent = false;
+
+    runCode(mockData);
+
+    const revokeCalls = fbqCalls.filter((c) => c[0] === 'consent' && c[1] === 'revoke');
+    assertThat(revokeCalls.length).isEqualTo(0);
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Consent] LDU sets dataProcessingOptions with country and state'
+  code: |-
+    mockData.dpoLDU = true;
+    mockData.dpoCountry = '1';
+    mockData.dpoState = '1000';
+
+    runCode(mockData);
+
+    const dpoCalls = fbqCalls.filter((c) => c[0] === 'dataProcessingOptions');
+    assertThat(dpoCalls.length).isEqualTo(1);
+    assertThat(dpoCalls[0][1]).isEqualTo(['LDU']);
+    assertThat(dpoCalls[0][2]).isEqualTo(1);
+    assertThat(dpoCalls[0][3]).isEqualTo(1000);
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Name] Maps GA4, stape, and gtm4wp events from DataLayer'
+  code: |-
+    [
+      { dlEvent: 'page_view', expected: 'PageView' },
+      { dlEvent: 'add_to_cart', expected: 'AddToCart' },
+      { dlEvent: 'purchase', expected: 'Purchase' },
+      { dlEvent: 'begin_checkout', expected: 'InitiateCheckout' },
+      { dlEvent: 'view_item', expected: 'ViewContent' },
+      { dlEvent: 'sign_up', expected: 'CompleteRegistration' },
+      { dlEvent: 'generate_lead', expected: 'Lead' },
+      { dlEvent: 'search', expected: 'Search' },
+      { dlEvent: 'add_to_wishlist', expected: 'AddToWishlist' },
+      { dlEvent: 'contact', expected: 'Contact' },
+      { dlEvent: 'subscribe', expected: 'Subscribe' },
+      { dlEvent: 'page_view_stape', expected: 'PageView' },
+      { dlEvent: 'purchase_stape', expected: 'Purchase' },
+      { dlEvent: 'add_to_cart_stape', expected: 'AddToCart' },
+      { dlEvent: 'gtm4wp.orderCompletedEEC', expected: 'Purchase' },
+      { dlEvent: 'gtm4wp.addProductToCartEEC', expected: 'AddToCart' },
+      { dlEvent: 'gtm4wp.productClickEEC', expected: 'ViewContent' }
+    ].forEach((scenario) => {
+      fbqCalls = [];
+      injectScriptCalls = [];
+
+      const testData = assign(assign({}, mockData), { inheritEventName: 'inherit' });
+
+      mock('copyFromDataLayer', (key) => {
+        if (key === 'event') return scenario.dlEvent;
+        return undefined;
+      });
+
+      mock('injectScript', (url, onsuccess) => {
+        injectScriptCalls.push({ url: url });
+        onsuccess();
+      });
+
+      runCode(testData);
+
+      const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle' || c[0] === 'trackSingleCustom');
+      assertThat(trackCalls.length).isEqualTo(1);
+      assertThat(trackCalls[0][2]).isEqualTo(scenario.expected);
+
+      assertApi('gtmOnSuccess').wasCalled();
+      assertApi('gtmOnFailure').wasNotCalled();
+    });
+- name: '[Event Name] Unmapped event from DataLayer passes through as-is'
+  code: |-
+    mockData.inheritEventName = 'inherit';
+
+    mock('copyFromDataLayer', (key) => {
+      if (key === 'event') return 'my_custom_dl_event';
+      return undefined;
+    });
+
+    runCode(mockData);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingleCustom');
+    assertThat(trackCalls.length).isEqualTo(1);
+    assertThat(trackCalls[0][2]).isEqualTo('my_custom_dl_event');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Name] UA ecommerce fallback when no DL event name'
+  code: |-
+    [
+      { ecommerceKey: 'detail', expected: 'ViewContent' },
+      { ecommerceKey: 'add', expected: 'AddToCart' },
+      { ecommerceKey: 'checkout', expected: 'InitiateCheckout' },
+      { ecommerceKey: 'purchase', expected: 'Purchase' }
+    ].forEach((scenario) => {
+      fbqCalls = [];
+      injectScriptCalls = [];
+
+      const testData = assign(assign({}, mockData), { inheritEventName: 'inherit' });
+      const ecommerceData = {};
+      ecommerceData[scenario.ecommerceKey] = true;
+
+      mock('copyFromDataLayer', (key, version) => {
+        if (key === 'event') return undefined;
+        if (key === 'ecommerce' && version === 1) return ecommerceData;
+        return undefined;
+      });
+
+      mock('injectScript', (url, onsuccess) => {
+        injectScriptCalls.push({ url: url });
+        onsuccess();
+      });
+
+      runCode(testData);
+
+      const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+      assertThat(trackCalls.length).isEqualTo(1);
+      assertThat(trackCalls[0][2]).isEqualTo(scenario.expected);
+
+      assertApi('gtmOnSuccess').wasCalled();
+      assertApi('gtmOnFailure').wasNotCalled();
+    });
+- name: '[Event Name] Override with standard and custom event types'
+  code: |-
+    const testData1 = assign(assign({}, mockData), {
+      inheritEventName: 'override',
+      eventName: 'standard',
+      eventNameStandard: 'AddToCart'
+    });
+
+    runCode(testData1);
+
+    let trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    assertThat(trackCalls.length).isEqualTo(1);
+    assertThat(trackCalls[0][2]).isEqualTo('AddToCart');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+
+    fbqCalls = [];
+    injectScriptCalls = [];
+
+    const testData2 = assign(assign({}, mockData), {
+      inheritEventName: 'override',
+      eventName: 'custom',
+      eventNameCustom: 'MyCustomEvent'
+    });
+
+    mock('injectScript', (url, onsuccess) => {
+      injectScriptCalls.push({ url: url });
+      onsuccess();
+    });
+
+    runCode(testData2);
+
+    trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingleCustom');
+    assertThat(trackCalls.length).isEqualTo(1);
+    assertThat(trackCalls[0][2]).isEqualTo('MyCustomEvent');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Pixel Init] Already initialized pixel skips re-init and settings'
+  code: |-
+    mock('copyFromWindow', (key) => {
+      if (key === 'fbq') return mockFbq;
+      if (key === '_meta_gtm_ids') return ['123456789'];
+      return undefined;
+    });
+
+    runCode(mockData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    assertThat(initCalls.length).isEqualTo(0);
+
+    const autoConfigCalls = fbqCalls.filter((c) => c[0] === 'set' && c[1] === 'autoConfig');
+    assertThat(autoConfigCalls.length).isEqualTo(0);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    assertThat(trackCalls.length).isEqualTo(1);
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Advanced Matching] User data from variable and table merged into init'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      userDataFromVariable: { email: 'test@example.com', phone: '+1234567890' },
+      userDataList: [{ name: 'fn', value: 'John' }, { name: 'ln', value: 'Doe' }]
+    });
+
+    runCode(testData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    assertThat(initCalls.length).isEqualTo(1);
+
+    const userData = initCalls[0][2];
+    assertThat(userData.em).isEqualTo('test@example.com');
+    assertThat(userData.ph).isEqualTo('+1234567890');
+    assertThat(userData.fn).isEqualTo('John');
+    assertThat(userData.ln).isEqualTo('Doe');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Advanced Matching] runInitOnce prevents re-init for initialized pixel'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      runInitOnce: true,
+      userDataFromVariable: { email: 'test@example.com' }
+    });
+
+    mock('copyFromWindow', (key) => {
+      if (key === 'fbq') return mockFbq;
+      if (key === '_meta_gtm_ids') return ['123456789'];
+      return undefined;
+    });
+
+    runCode(testData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    assertThat(initCalls.length).isEqualTo(0);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    assertThat(trackCalls.length).isEqualTo(1);
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[User Data] Parses all fields from DataLayer user_data object'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      enableDataLayerMapping: true
+    });
+
+    mock('copyFromDataLayer', (key) => {
+      if (key === 'user_data') return {
+        email: 'dl@example.com',
+        phone: '+1555000000',
+        firstName: 'Jane',
+        lastName: 'Smith',
+        city: 'New York',
+        state: 'NY',
+        zip: '10001',
+        country: 'US',
+        external_id: 'ext123',
+        ge: 'f',
+        db: '19900101'
+      };
+      return undefined;
+    });
+
+    runCode(testData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    const userData = initCalls[0][2];
+    assertThat(userData.em).isEqualTo('dl@example.com');
+    assertThat(userData.ph).isEqualTo('+1555000000');
+    assertThat(userData.fn).isEqualTo('Jane');
+    assertThat(userData.ln).isEqualTo('Smith');
+    assertThat(userData.ct).isEqualTo('New York');
+    assertThat(userData.st).isEqualTo('NY');
+    assertThat(userData.zp).isEqualTo('10001');
+    assertThat(userData.country).isEqualTo('US');
+    assertThat(userData.external_id).isEqualTo('ext123');
+    assertThat(userData.ge).isEqualTo('f');
+    assertThat(userData.db).isEqualTo('19900101');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[User Data] Array email and phone values take the first element'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      userDataFromVariable: {
+        email: ['first@example.com', 'second@example.com'],
+        phone: ['+111', '+222']
+      }
+    });
+
+    runCode(testData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    const userData = initCalls[0][2];
+    assertThat(userData.em).isEqualTo('first@example.com');
+    assertThat(userData.ph).isEqualTo('+111');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[User Data] Address-nested fields are parsed correctly'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      userDataFromVariable: {
+        address: {
+          first_name: 'Nested',
+          last_name: 'User',
+          city: 'Boston',
+          state: 'MA',
+          postal_code: '02101',
+          country: 'US'
+        }
+      }
+    });
+
+    runCode(testData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    const userData = initCalls[0][2];
+    assertThat(userData.fn).isEqualTo('Nested');
+    assertThat(userData.ln).isEqualTo('User');
+    assertThat(userData.ct).isEqualTo('Boston');
+    assertThat(userData.st).isEqualTo('MA');
+    assertThat(userData.zp).isEqualTo('02101');
+    assertThat(userData.country).isEqualTo('US');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[User Data] Empty or all-falsy user data returns undefined'
+  code: |-
+    [
+      { description: 'empty object', userData: {} },
+      { description: 'all-falsy values', userData: { email: '', phone: null } }
+    ].forEach((scenario) => {
+      fbqCalls = [];
+      const testData = assign(assign({}, mockData), {
+        enableEdvancedMatching: true,
+        userDataFromVariable: scenario.userData
+      });
+
+      runCode(testData);
+
+      const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+      assertThat(initCalls.length).isEqualTo(1);
+      assertThat(initCalls[0][2]).isUndefined();
+
+      assertApi('gtmOnSuccess').wasCalled();
+      assertApi('gtmOnFailure').wasNotCalled();
+    });
+- name: '[User Data] External ID falls back to DataLayer when useDL is true'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      enableDataLayerMapping: true
+    });
+
+    mock('copyFromDataLayer', (key) => {
+      if (key === 'user_data') return { email: 'test@example.com' };
+      if (key === 'external_id') return 'dl-ext-id';
+      return undefined;
+    });
+
+    runCode(testData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    const userData = initCalls[0][2];
+    assertThat(userData.external_id).isEqualTo('dl-ext-id');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Data] GA4 Purchase with multiple items builds correct properties'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      eventNameStandard: 'Purchase',
+      enableDataLayerMapping: true
+    });
+
+    mock('copyFromDataLayer', (key) => {
+      if (key === 'items') return [
+        { item_id: 'SKU1', item_name: 'Product 1', price: 10, quantity: 2, currency: 'EUR' },
+        { item_id: 'SKU2', item_name: 'Product 2', price: 25, quantity: 1 }
+      ];
+      if (key === 'value') return 45;
+      if (key === 'currency') return 'EUR';
+      return undefined;
+    });
+
+    runCode(testData);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    assertThat(trackCalls.length).isEqualTo(1);
+
+    const eventData = trackCalls[0][3];
+    assertThat(eventData.content_type).isEqualTo('product');
+    assertThat(eventData.content_ids).isEqualTo(['SKU1', 'SKU2']);
+    assertThat(eventData.contents.length).isEqualTo(2);
+    assertThat(eventData.contents[0].id).isEqualTo('SKU1');
+    assertThat(eventData.contents[0].quantity).isEqualTo(2);
+    assertThat(eventData.contents[1].id).isEqualTo('SKU2');
+    assertThat(eventData.contents[1].quantity).isEqualTo(1);
+    assertThat(eventData.value).isEqualTo(45);
+    assertThat(eventData.currency).isEqualTo('EUR');
+    assertThat(eventData.num_items).isDefined();
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Data] GA4 single item includes content_name and content_category'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      eventNameStandard: 'ViewContent',
+      enableDataLayerMapping: true
+    });
+
+    mock('copyFromDataLayer', (key) => {
+      if (key === 'items') return [
+        { item_id: 'SINGLE1', item_name: 'My Product', item_category: 'Electronics', price: 99, quantity: 1 }
+      ];
+      return undefined;
+    });
+
+    runCode(testData);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    const eventData = trackCalls[0][3];
+    assertThat(eventData.content_name).isEqualTo('My Product');
+    assertThat(eventData.content_category).isEqualTo('Electronics');
+    assertThat(eventData.content_type).isEqualTo('product');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Data] UA Purchase with products builds correct properties'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      eventNameStandard: 'Purchase',
+      enableDataLayerMapping: true
+    });
+
+    mock('copyFromDataLayer', (key) => {
+      if (key === 'ecommerce') return {
+        currencyCode: 'GBP',
+        purchase: {
+          products: [
+            { id: 'P1', price: '15.99', quantity: '3' },
+            { id: 'P2', price: '8.50', quantity: '1' }
+          ]
+        }
+      };
+      return undefined;
+    });
+
+    runCode(testData);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    assertThat(trackCalls.length).isEqualTo(1);
+
+    const eventData = trackCalls[0][3];
+    assertThat(eventData.content_type).isEqualTo('product');
+    assertThat(eventData.content_ids).isEqualTo(['P1', 'P2']);
+    assertThat(eventData.currency).isEqualTo('GBP');
+    assertThat(eventData.contents.length).isEqualTo(2);
+    assertThat(eventData.num_items).isDefined();
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Data] Properties from variable and table list merge correctly'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      objectPropertiesFromVariable: { content_name: 'My Product', value: 99 },
+      objectPropertiesList: [
+        { name: 'currency', value: 'USD' },
+        { name: 'content_type', value: 'product' }
+      ]
+    });
+
+    runCode(testData);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    const eventData = trackCalls[0][3];
+    assertThat(eventData.content_name).isEqualTo('My Product');
+    assertThat(eventData.value).isEqualTo(99);
+    assertThat(eventData.currency).isEqualTo('USD');
+    assertThat(eventData.content_type).isEqualTo('product');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Data] GA4 Search event includes search_string'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      eventNameStandard: 'Search',
+      enableDataLayerMapping: true
+    });
+
+    mock('copyFromDataLayer', (key) => {
+      if (key === 'search_term') return 'blue shoes';
+      return undefined;
+    });
+
+    runCode(testData);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    const eventData = trackCalls[0][3];
+    assertThat(eventData.search_string).isEqualTo('blue shoes');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Data] GA4 Purchase defaults currency to USD and value to 0'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      eventNameStandard: 'Purchase',
+      enableDataLayerMapping: true
+    });
+
+    mock('copyFromDataLayer', () => undefined);
+
+    runCode(testData);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    const eventData = trackCalls[0][3];
+    assertThat(eventData.currency).isEqualTo('USD');
+    assertThat(eventData.value).isEqualTo(0);
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Settings] disableAutoConfig and disablePushState are applied correctly'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      disableAutoConfig: true,
+      disablePushState: true
+    });
+
+    runCode(testData);
+
+    const autoConfigCalls = fbqCalls.filter((c) => c[0] === 'set' && c[1] === 'autoConfig');
+    assertThat(autoConfigCalls.length).isEqualTo(1);
+    assertThat(autoConfigCalls[0][2]).isFalse();
+    assertThat(autoConfigCalls[0][3]).isEqualTo('123456789');
+
+    const pushStateCalls = setInWindowCalls.filter((c) => c[0] === 'fbq.disablePushState');
+    assertThat(pushStateCalls.length).isEqualTo(1);
+    assertThat(pushStateCalls[0][1]).isTrue();
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[DataLayer Push] Pushes event with custom and default settings'
+  code: |-
+    [
+      {
+        desc: 'custom name and layer',
+        dataLayerEventName: 'fb_pageview',
+        dataLayerVariableName: 'myDataLayer',
+        eventId: 'evt-123',
+        expectedLayer: 'myDataLayer',
+        expectedEvent: 'fb_pageview'
+      },
+      {
+        desc: 'defaults when not specified',
+        dataLayerEventName: undefined,
+        dataLayerVariableName: undefined,
+        eventId: 'evt-456',
+        expectedLayer: 'dataLayer',
+        expectedEvent: 'DefaultTagEvent'
+      }
+    ].forEach((scenario) => {
+      createQueueItems = [];
+      const testData = assign(assign({}, mockData), {
+        dataLayerEventPush: true,
+        dataLayerEventName: scenario.dataLayerEventName,
+        dataLayerVariableName: scenario.dataLayerVariableName,
+        eventId: scenario.eventId
+      });
+
+      runCode(testData);
+
+      const dlPushes = createQueueItems.filter((c) => c[0] === scenario.expectedLayer);
+      assertThat(dlPushes.length).isEqualTo(1);
+      assertThat(dlPushes[0][1].event).isEqualTo(scenario.expectedEvent);
+      assertThat(dlPushes[0][1].eventId).isEqualTo(scenario.eventId);
+
+      assertApi('gtmOnSuccess').wasCalled();
+      assertApi('gtmOnFailure').wasNotCalled();
+    });
+- name: '[Scripts] fbevents failure calls gtmOnFailure'
+  code: |-
+    mock('injectScript', (url, onsuccess, onfailure) => {
+      if (url === 'https://connect.facebook.net/en_US/fbevents.js') {
+        onfailure();
+      }
+    });
+
+    runCode(mockData);
+
+    assertApi('gtmOnSuccess').wasNotCalled();
+    assertApi('gtmOnFailure').wasCalled();
+- name: '[Event Enhancement] Reads stored data from localStorage and writes back'
+  code: |-
+    localStorageData.gtmeec = '{"em":"stored@example.com"}';
+
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      enableEventEnhancement: true,
+      userDataFromVariable: { ph: '+1999999999' }
+    });
+
+    runCode(testData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    const userData = initCalls[0][2];
+    assertThat(userData.em).isEqualTo('stored@example.com');
+    assertThat(userData.ph).isEqualTo('+1999999999');
+
+    assertThat(localStorageData.gtmeec).isDefined();
+    const stored = JSON.parse(localStorageData.gtmeec);
+    assertThat(stored.em).isEqualTo('stored@example.com');
+    assertThat(stored.ph).isEqualTo('+1999999999');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Enhancement] Hashed storage calls hashUserDataFields with sync hash'
+  code: |-
+    mock('copyFromWindow', (key) => {
+      if (key === 'fbq') return mockFbq;
+      if (key === 'dataTag256') return function() { return 'abc123hash'; };
+      return undefined;
+    });
+
+    mock('callInWindow', (key) => {
+      if (key === 'dataTag256') return 'abc123hash';
+      return undefined;
+    });
+
+
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      enableEventEnhancement: true,
+      storeUserDataHashed: true,
+      userDataFromVariable: { email: 'test@example.com' }
+    });
+
+    runCode(testData);
+
+    assertThat(localStorageData.gtmeec).isDefined();
+    const stored = JSON.parse(localStorageData.gtmeec);
+    assertThat(stored.em).isEqualTo('abc123hash');
+
+    assertApi('callInWindow').wasCalledWith('dataTag256', 'test@example.com', 'HEX');
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event Enhancement] Hashed storage with async sha256 stores hashed data'
+  code: |-
+    mock('sha256', (input, successCb, errorCb, options) => {
+      successCb('async_hashed_' + input);
+    });
+
+    mock('copyFromWindow', (key) => {
+      if (key === 'fbq') return mockFbq;
+      return undefined;
+    });
+
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      enableEventEnhancement: true,
+      storeUserDataHashed: true,
+      userDataFromVariable: { email: 'test@example.com' }
+    });
+
+    runCode(testData);
+
+    assertThat(localStorageData.gtmeec).isDefined();
+    const stored = JSON.parse(localStorageData.gtmeec);
+    assertThat(stored.em).isEqualTo('async_hashed_test@example.com');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Event ID] Passes eventID option in track call'
+  code: |-
+    mockData.eventId = 'evt-abc-123';
+
+    runCode(mockData);
+
+    const trackCalls = fbqCalls.filter((c) => c[0] === 'trackSingle');
+    assertThat(trackCalls.length).isEqualTo(1);
+    assertThat(trackCalls[0][4]).isEqualTo({ eventID: 'evt-abc-123' });
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Advanced Matching] Re-inits initialized pixel when runInitOnce is false'
+  code: |-
+    const testData = assign(assign({}, mockData), {
+      enableEdvancedMatching: true,
+      runInitOnce: false,
+      userDataFromVariable: { email: 'test@example.com' }
+    });
+
+    mock('copyFromWindow', (key) => {
+      if (key === 'fbq') return mockFbq;
+      if (key === '_meta_gtm_ids') return ['123456789'];
+      return undefined;
+    });
+
+    runCode(testData);
+
+    const initCalls = fbqCalls.filter((c) => c[0] === 'init');
+    assertThat(initCalls.length).isEqualTo(1);
+    assertThat(initCalls[0][2].em).isEqualTo('test@example.com');
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: '[DL Version] enableCurrentDataLayerOnly uses DL version 1'
+  code: |-
+    let capturedVersion;
+    mock('copyFromDataLayer', (key, version) => {
+      if (key === 'search_term') {
+        capturedVersion = version;
+        return 'test query';
+      }
+      return undefined;
+    });
+
+    const testData = assign(assign({}, mockData), {
+      enableDataLayerMapping: true,
+      enableCurrentDataLayerOnly: true,
+      eventNameStandard: 'Search'
+    });
+
+    runCode(testData);
+
+    assertThat(capturedVersion).isEqualTo(1);
+
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
 setup: |-
-  const mockData = {
-    pixelIds: '123456789,987654321',
-    consent: true,
-    eventId: 'test'
+  const JSON = require('JSON');
+  const Object = require('Object');
+
+  const PARTNER_AGENT_VERSION = 'stape-gtm-1.1.1';
+
+  const assign = (target, source) => {
+    if (!source) return target;
+    Object.keys(source).forEach((key) => { target[key] = source[key]; });
+    return target;
   };
 
+  let fbqCalls = [];
+  const mockFbq = function() {
+    const args = [];
+    for (let i = 0; i < arguments.length; i++) {
+      args.push(arguments[i]);
+    }
+    fbqCalls.push(args);
+  };
+  mockFbq.queue = [];
 
-  let success, failure;
-  mock('injectScript', (url, onsuccess, onfailure) => {
-    success = onsuccess;
-    failure = onfailure;
+  let setInWindowCalls = [];
+  mock('setInWindow', (key, value, override) => {
+    setInWindowCalls.push([key, value, override]);
+  });
+
+  let injectScriptCalls = [];
+  mock('injectScript', (url, onsuccess, onfailure, cacheToken) => {
+    injectScriptCalls.push({ url: url, onsuccess: onsuccess, onfailure: onfailure, cacheToken: cacheToken });
     onsuccess();
   });
 
-  mock('copyFromWindow', key => {
-    if (key === 'fbq') return () => {};
-    if (key === 'dataLayer') return () => {};
+  mock('copyFromWindow', (key) => {
+    if (key === 'fbq') return mockFbq;
+    return undefined;
   });
+
+  mock('aliasInWindow', () => true);
+
+  let createQueueItems = [];
+  mock('createQueue', (name) => {
+    return (item) => { createQueueItems.push([name, item]); };
+  });
+
+  mock('copyFromDataLayer', () => undefined);
+  mock('isConsentGranted', () => true);
+  mock('addConsentListener', () => {});
+
+  let templateStorageData = {};
+  mockObject('templateStorage', {
+    getItem: (key) => templateStorageData[key],
+    setItem: (key, value) => { templateStorageData[key] = value; }
+  });
+
+  let localStorageData = {};
+  mockObject('localStorage', {
+    getItem: (key) => localStorageData[key],
+    setItem: (key, value) => { localStorageData[key] = value; }
+  });
+
+  const mockData = {
+    pixelIds: '123456789',
+    consent: true,
+    enableConsentMode: false,
+    inheritEventName: 'override',
+    eventName: 'standard',
+    eventNameStandard: 'PageView',
+    enableDataLayerMapping: false,
+    enableEdvancedMatching: false,
+    dpoLDU: false,
+    disableAutoConfig: false,
+    disablePushState: false,
+    dataLayerEventPush: false,
+    enableEventEnhancement: false,
+    storeUserDataHashed: false,
+    runInitOnce: false,
+    enableCurrentDataLayerOnly: false
+  };
 
 
 ___NOTES___

--- a/template.tpl
+++ b/template.tpl
@@ -660,7 +660,7 @@ const partnerName = 'stape-gtm-1.1.1';
 setConsent(isConsentRevoked);
 sendEvent();
 sendDataLayerPush();
-runOnConsent('ad_storage', () => {
+runOnConsentGranted('ad_storage', isConsentRevoked, () => {
   loadScripts();
 });
 
@@ -699,11 +699,9 @@ function setFbqConsent(command) {
   queue('consent', command);
 }
 
-function runOnConsent(consentType, callback) {
+function runOnConsentGranted(consentType, isConsentRevoked, callback) {
   if (data.enableConsentMode) {
-    if (isConsentGranted(consentType)) {
-      callback();
-    } else {
+    if (isConsentRevoked) {
       const callbacksKey = 'fbq_consent_callbacks_' + consentType;
       const callbacks = templateStorage.getItem(callbacksKey) || [];
       callbacks.push(callback);
@@ -715,16 +713,18 @@ function runOnConsent(consentType, callback) {
         addConsentListener(consentType, (type, granted) => {
           if (type !== consentType || !granted) return;
           const queuedCallbacks = templateStorage.getItem(callbacksKey) || [];
-          queuedCallbacks.forEach((cb) => cb());
           templateStorage.setItem(callbacksKey, []);
+          queuedCallbacks.forEach((cb) => cb());
         });
       }
+    } else {
+      callback();
     }
     return;
   }
 
-  const isConsentManuallyGranted = data.consent !== false;
-  if (isConsentManuallyGranted) callback();
+  // Manual consent
+  if (!isConsentRevoked) callback();
 }
 
 function setConsent(isConsentRevoked) {
@@ -734,8 +734,7 @@ function setConsent(isConsentRevoked) {
 
   if (isConsentRevoked) setFbqConsent('revoke');
 
-  // Wait for consent to send 'grant'
-  runOnConsent('ad_storage', () => {
+  runOnConsentGranted('ad_storage', isConsentRevoked, () => {
     setFbqConsent('grant');
   });
 }
@@ -1776,7 +1775,7 @@ ___WEB_PERMISSIONS___
 ___TESTS___
 
 scenarios:
-- name: '[Happy Path] PageView fires init, agent, trackSingle and injects both scripts'
+- name: '[Happy Path] PageView fires init, agent, trackSingle and injects scripts'
   code: |-
     runCode(mockData);
 


### PR DESCRIPTION
## Summary

- Refactor consent logic: defer script loading until consent is granted (either via Google Consent Mode or manually), prevent duplicate `revoke` commands from locking the queue, and support multiple consent callbacks via `templateStorage`
- Bump version to `stape-gtm-1.1.1`
- UI improvements: move `enableCurrentDataLayerOnly` under `enableDataLayerMapping` as sub-param, update help texts, add pixel ID value hint
- Add unit tests

## Important change

- `fbevents.js` is no longer loaded before consent is granted (previously it loaded immediately and was held by `fbq('consent', 'revoke')`). Users relying on the pixel SDK being present in the page before consent will notice the change.