### PR TITLE
Prevent multiple Param Builder SDK injections and skip on Magento 2 Checkout

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,10 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/fb-tag'
 versions:
+  - sha: a2ee28e337f36eaea393a77e6c14fdaf6c29488d
+    changeNotes: |2
+      Prevent Param Builder SDK from being re-injected and called more than once per page.
+      Skip Param Builder SDK load on Magento 2 Checkout pages to avoid conflicts with RequireJS.
   - sha: c94461ee086c1a458cd43d0135d24d41485b8ec3
     changeNotes: |2
       Add optional Meta Parameter Builder SDK integration.

--- a/template.js
+++ b/template.js
@@ -572,17 +572,22 @@ function loadScripts(isParamBuilderSdkEnabled) {
     'metaPixel'
   );
 
-  if (isParamBuilderSdkEnabled) {
+  const isParamBuilderSdkLoadedOrLoading = !!copyFromWindow('_meta_param_builder_sdk_status');
+  if (isParamBuilderSdkEnabled && !isParamBuilderSdkLoadedOrLoading && !isMagento2Checkout()) {
+    setInWindow('_meta_param_builder_sdk_status', 'loading', true);
     injectScript(
       'https://unpkg.com/meta-capi-param-builder-clientjs/dist/clientParamBuilder.bundle.js',
       () => {
+        setInWindow('_meta_param_builder_sdk_status', 'loaded', true);
         if (copyFromWindow('clientParamBuilder.processAndCollectAllParams')) {
           callInWindow('clientParamBuilder.processAndCollectAllParams');
         } else if (copyFromWindow('clientParamBuilder.processAndCollectParams')) {
           callInWindow('clientParamBuilder.processAndCollectParams');
         }
       },
-      () => {},
+      () => {
+        setInWindow('_meta_param_builder_sdk_status', undefined, true);
+      },
       'metaParamBuilderSdk'
     );
   }
@@ -623,4 +628,10 @@ function normalizePhoneNumber(phoneNumber) {
 function removeWhiteSpace(input) {
   if (!input) return input;
   return input.split(' ').join('');
+}
+
+function isMagento2Checkout() {
+  const checkoutConfig = copyFromWindow('checkoutConfig');
+
+  return getType(checkoutConfig) === 'object' && getType(checkoutConfig.quoteData) === 'object' && checkoutConfig.hasOwnProperty('defaultSuccessPageUrl') && checkoutConfig.hasOwnProperty('storeCode');
 }

--- a/template.tpl
+++ b/template.tpl
@@ -1201,17 +1201,22 @@ function loadScripts(isParamBuilderSdkEnabled) {
     'metaPixel'
   );
 
-  if (isParamBuilderSdkEnabled) {
+  const isParamBuilderSdkLoadedOrLoading = !!copyFromWindow('_meta_param_builder_sdk_status');
+  if (isParamBuilderSdkEnabled && !isParamBuilderSdkLoadedOrLoading && !isMagento2Checkout()) {
+    setInWindow('_meta_param_builder_sdk_status', 'loading', true);
     injectScript(
       'https://unpkg.com/meta-capi-param-builder-clientjs/dist/clientParamBuilder.bundle.js',
       () => {
+        setInWindow('_meta_param_builder_sdk_status', 'loaded', true);
         if (copyFromWindow('clientParamBuilder.processAndCollectAllParams')) {
           callInWindow('clientParamBuilder.processAndCollectAllParams');
         } else if (copyFromWindow('clientParamBuilder.processAndCollectParams')) {
           callInWindow('clientParamBuilder.processAndCollectParams');
         }
       },
-      () => {},
+      () => {
+        setInWindow('_meta_param_builder_sdk_status', undefined, true);
+      },
       'metaParamBuilderSdk'
     );
   }
@@ -1252,6 +1257,12 @@ function normalizePhoneNumber(phoneNumber) {
 function removeWhiteSpace(input) {
   if (!input) return input;
   return input.split(' ').join('');
+}
+
+function isMagento2Checkout() {
+  const checkoutConfig = copyFromWindow('checkoutConfig');
+
+  return getType(checkoutConfig) === 'object' && getType(checkoutConfig.quoteData) === 'object' && checkoutConfig.hasOwnProperty('defaultSuccessPageUrl') && checkoutConfig.hasOwnProperty('storeCode');
 }
 
 
@@ -1696,6 +1707,84 @@ ___WEB_PERMISSIONS___
                   {
                     "type": 8,
                     "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "_meta_param_builder_sdk_status"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "checkoutConfig"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
                   }
                 ]
               }
@@ -2588,21 +2677,6 @@ scenarios:
     assertApi('callInWindow').wasCalledWith('clientParamBuilder.processAndCollectAllParams');
     assertApi('gtmOnSuccess').wasCalled();
     assertApi('gtmOnFailure').wasNotCalled();
-- name: '[Scripts] Param builder falls back to processAndCollectParams'
-  code: |-
-    mock('copyFromWindow', (key) => {
-      if (key === 'fbq') return mockFbq;
-      if (key === 'clientParamBuilder.processAndCollectAllParams') return undefined;
-      if (key === 'clientParamBuilder.processAndCollectParams') return function() {};
-      return undefined;
-    });
-
-    runCode(mockData);
-
-    assertThat(injectScriptCalls.length).isEqualTo(2);
-    assertApi('callInWindow').wasCalledWith('clientParamBuilder.processAndCollectParams');
-    assertApi('gtmOnSuccess').wasCalled();
-    assertApi('gtmOnFailure').wasNotCalled();
 - name: '[Scripts] Param builder disabled injects only fbevents and removes -pb suffix'
   code: |-
     const testData = assign(assign({}, mockData), { enableParamBuilderSdk: false });
@@ -2617,6 +2691,45 @@ scenarios:
 
     assertApi('gtmOnSuccess').wasCalled();
     assertApi('gtmOnFailure').wasNotCalled();
+- name: '[Scripts] Param builder not injected again when already loaded or loading'
+  code: |2-
+       ['loading', 'loaded'].forEach((status) => {
+          injectScriptCalls = [];
+
+          mock('copyFromWindow', (key) => {
+            if (key === 'fbq') return mockFbq;
+            if (key === '_meta_param_builder_sdk_status') return status;
+            return undefined;
+          });
+
+          runCode(mockData);
+
+          assertThat(injectScriptCalls.length).isEqualTo(1);
+          assertThat(injectScriptCalls[0].url).isEqualTo('https://connect.facebook.net/en_US/fbevents.js');
+
+          assertApi('gtmOnSuccess').wasCalled();
+          assertApi('gtmOnFailure').wasNotCalled();
+        });
+- name: '[Scripts] Param builder not injected on Magento 2 Checkout'
+  code: |2-
+       const checkoutConfig = {};
+        checkoutConfig.quoteData = {};
+        checkoutConfig.defaultSuccessPageUrl = '/checkout/success';
+        checkoutConfig.storeCode = 'default';
+
+        mock('copyFromWindow', (key) => {
+          if (key === 'fbq') return mockFbq;
+          if (key === 'checkoutConfig') return checkoutConfig;
+          return undefined;
+        });
+
+        runCode(mockData);
+
+        assertThat(injectScriptCalls.length).isEqualTo(1);
+        assertThat(injectScriptCalls[0].url).isEqualTo('https://connect.facebook.net/en_US/fbevents.js');
+
+        assertApi('gtmOnSuccess').wasCalled();
+        assertApi('gtmOnFailure').wasNotCalled();
 - name: '[Scripts] fbevents failure calls gtmOnFailure'
   code: |-
     mock('injectScript', (url, onsuccess, onfailure) => {
@@ -2879,6 +2992,10 @@ setup: |-
 
 
 ___NOTES___
+
+2026-05-13 - Change Notes:
+  - Prevent Param Builder SDK from being re-injected when it is already loading or has loaded, using a window-level status flag (_meta_param_builder_sdk_status)
+  - Skip Param Builder SDK injection on Magento 2 checkout pages to avoid compatibility conflicts
 
 2026-04-09 - Change Notes:
   - Add optional Meta Parameter Builder SDK integration (enabled by default) to improve _fbp and _fbc cookie coverage, including backup Click ID retrieval from in-app browsers


### PR DESCRIPTION
**SDK Injection Logic Improvements:**
* Added a window-level status flag (`_meta_param_builder_sdk_status`) to prevent the Meta Parameter Builder SDK from being injected or called more than once per page. The script now checks this flag before attempting injection and updates it on load success or failure. [[1]](diffhunk://#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210L575-R590) [[2]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L1204-R1219)

* Introduced the `isMagento2Checkout` function to detect Magento 2 checkout pages and skip SDK injection in these contexts to avoid conflicts with RequireJS. See https://github.com/facebook/capi-param-builder/issues/28.  [[1]](diffhunk://#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R632-R646) [[2]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292R1262-R1276)